### PR TITLE
Opt-in FP16 Metal inference path

### DIFF
--- a/src/nn/metal/metal_common.h
+++ b/src/nn/metal/metal_common.h
@@ -9,6 +9,7 @@
 #include "../network_tensor_plan.h"
 
 #include <cstdint>
+#include <cstdlib>
 #include <stdexcept>
 #include <vector>
 
@@ -17,6 +18,16 @@ namespace NN {
 namespace Metal {
 
 static int kInputPlanes = kPackedInputPlaneCount;
+
+// Opt-in FP16 compute for the MPSGraph transformer body (METALFISH_METAL_FP16).
+// Default is FP32. FP16 is ~14% faster per eval at batch 1 with near-identical
+// outputs, but can change move selection on borderline positions, so it stays
+// opt-in pending large-scale strength validation.
+inline bool HalfPrecisionEnabled() {
+  const char *e = std::getenv("METALFISH_METAL_FP16");
+  return e && (e[0] == '1' || e[0] == 't' || e[0] == 'T' || e[0] == 'y' ||
+               e[0] == 'Y');
+}
 
 struct InputsOutputs {
   InputsOutputs(int maxBatchSize, const NetworkTensorPlan &plan) {

--- a/src/nn/metal/metal_network.mm
+++ b/src/nn/metal/metal_network.mm
@@ -164,7 +164,8 @@ std::string MetalNetwork::GetNetworkInfo() const {
       << (attn_policy_ ? "attention" : (conv_policy_ ? "conv" : "classical"))
       << "\n";
   oss << "Value head: " << (wdl_ ? "WDL" : "scalar") << "\n";
-  oss << "Moves left: " << (moves_left_ ? "yes" : "no");
+  oss << "Moves left: " << (moves_left_ ? "yes" : "no") << "\n";
+  oss << "Precision: " << (HalfPrecisionEnabled() ? "FP16" : "FP32");
   return oss.str();
 }
 

--- a/src/nn/metal/mps/NetworkGraph.h
+++ b/src/nn/metal/mps/NetworkGraph.h
@@ -40,6 +40,13 @@
   dispatch_semaphore_t _doubleBufferingSemaphore;
 
   float *__nullable _globalSmolgenWeights;
+
+  // Compute precision for the transformer body. FP32 by default; set to
+  // MPSDataTypeFloat16 (via METALFISH_METAL_FP16) to run weights/activations in
+  // half precision. Inputs are fed and outputs decoded as FP32 regardless.
+  MPSDataType _computeType;
+  // Keeps host-converted FP16 weight buffers alive for the graph's lifetime.
+  NSMutableArray<NSData *> *__nullable _retainedWeightData;
 }
 
 + (MetalNetworkGraph *_Nullable)getGraphAt:(NSNumber *_Nonnull)index;
@@ -205,6 +212,13 @@
                       label:(NSString *__nonnull)label;
 
 - (void)setGlobalSmolgenWeights:(float *__nonnull)weights;
+
+// Creates a weight variable from FP32 host data, converting to the graph's
+// compute precision (_computeType) when running in FP16.
+- (nonnull MPSGraphTensor *)weightVariableWithData:(NSData *__nonnull)data
+                                             shape:(MPSShape *__nonnull)shape
+                                          dataType:(MPSDataType)dataType
+                                              name:(NSString *__nonnull)name;
 
 - (void)setResultTensors:(NSArray<MPSGraphTensor *> *__nonnull)results;
 

--- a/src/nn/metal/mps/NetworkGraph.mm
+++ b/src/nn/metal/mps/NetworkGraph.mm
@@ -9,6 +9,7 @@
 #import "../../tables/attention_policy_map.h"
 #import "../../tables/conv_policy_map.h"
 #import "../../weights.h"
+#import "../metal_common.h"
 #import <algorithm>
 #import <vector>
 
@@ -119,6 +120,11 @@ static const NSInteger kMinSubBatchSize = 20;
   _doubleBufferingSemaphore = dispatch_semaphore_create(kMaxInflightBuffers);
   _resultDataDicts =
       [NSMutableDictionary dictionaryWithCapacity:kMaxInflightBuffers];
+
+  _retainedWeightData = [[NSMutableArray alloc] init];
+  _computeType = MetalFish::NN::Metal::HalfPrecisionEnabled()
+                     ? MPSDataTypeFloat16
+                     : MPSDataTypeFloat32;
 
   return self;
 }
@@ -260,7 +266,42 @@ static const NSInteger kMinSubBatchSize = 20;
   }
 }
 
+- (nonnull MPSGraphTensor *)weightVariableWithData:(NSData *__nonnull)data
+                                             shape:(MPSShape *__nonnull)shape
+                                          dataType:(MPSDataType)dataType
+                                              name:(NSString *__nonnull)name {
+  if (_computeType == MPSDataTypeFloat16 && dataType == MPSDataTypeFloat32) {
+    const NSUInteger count = data.length / sizeof(float);
+    const float *src = (const float *)data.bytes;
+    NSMutableData *half = [NSMutableData dataWithLength:count * sizeof(__fp16)];
+    __fp16 *dst = (__fp16 *)half.mutableBytes;
+    for (NSUInteger i = 0; i < count; ++i)
+      dst[i] = (__fp16)src[i];
+    [_retainedWeightData addObject:half];
+    return [super variableWithData:half
+                             shape:shape
+                          dataType:MPSDataTypeFloat16
+                              name:name];
+  }
+  return [super variableWithData:data shape:shape dataType:dataType name:name];
+}
+
 - (void)setResultTensors:(NSArray<MPSGraphTensor *> *__nonnull)results {
+  if (_computeType != MPSDataTypeFloat32) {
+    NSMutableArray<MPSGraphTensor *> *casted =
+        [NSMutableArray arrayWithCapacity:results.count];
+    NSUInteger idx = 0;
+    for (MPSGraphTensor *tensor in results) {
+      [casted
+          addObject:[self
+                        castTensor:tensor
+                            toType:MPSDataTypeFloat32
+                              name:[NSString
+                                       stringWithFormat:@"result/fp32/%lu",
+                                                        (unsigned long)idx++]]];
+    }
+    results = casted;
+  }
   _resultTensors = results;
   _targetTensors = [NSArray arrayWithArray:_resultTensors];
   _targetTensors =
@@ -374,10 +415,17 @@ static const NSInteger kMinSubBatchSize = 20;
                                                            label]];
 
   // Reshape to final output format [batch_size, kInputPlanes, 8, 8]
-  return [self
+  MPSGraphTensor *reshaped = [self
       reshapeTensor:expandedMaskTensor
           withShape:@[ @(-1), valueTensor.shape[1], @8, @8 ]
                name:[NSString stringWithFormat:@"%@/input/reshape", label]];
+  if (_computeType != MPSDataTypeFloat32) {
+    reshaped = [self
+        castTensor:reshaped
+            toType:_computeType
+              name:[NSString stringWithFormat:@"%@/input/compute", label]];
+  }
+  return reshaped;
 }
 
 - (nonnull MPSGraphTensor *)
@@ -408,8 +456,8 @@ static const NSInteger kMinSubBatchSize = 20;
                                   kernelSize * sizeof(float)
                      freeWhenDone:NO];
 
-  MPSGraphTensor *weightsTensor =
-      [self variableWithData:weightsData
+  MPSGraphTensor *weightsTensor = [self
+      weightVariableWithData:weightsData
                        shape:@[
                          @(outputChannels), @(inputChannels), @(kernelSize),
                          @(kernelSize)
@@ -421,8 +469,8 @@ static const NSInteger kMinSubBatchSize = 20;
                                           length:outputChannels * sizeof(float)
                                     freeWhenDone:NO];
 
-  MPSGraphTensor *biasTensor =
-      [self variableWithData:biasData
+  MPSGraphTensor *biasTensor = [self
+      weightVariableWithData:biasData
                        shape:@[ @(outputChannels), @1, @1 ]
                     dataType:MPSDataTypeFloat32
                         name:[NSString stringWithFormat:@"%@/biases", label]];
@@ -520,8 +568,8 @@ static const NSInteger kMinSubBatchSize = 20;
                            length:outputChannels * inputChannels * sizeof(float)
                      freeWhenDone:NO];
 
-  MPSGraphTensor *weightTensor =
-      [self variableWithData:weightData
+  MPSGraphTensor *weightTensor = [self
+      weightVariableWithData:weightData
                        shape:@[ @(outputChannels), @(inputChannels) ]
                     dataType:MPSDataTypeFloat32
                         name:[NSString stringWithFormat:@"%@/weights", label]];
@@ -547,8 +595,8 @@ static const NSInteger kMinSubBatchSize = 20;
                              length:outputChannels * sizeof(float)
                        freeWhenDone:NO];
 
-    MPSGraphTensor *biasTensor =
-        [self variableWithData:biasData
+    MPSGraphTensor *biasTensor = [self
+        weightVariableWithData:biasData
                          shape:@[ @(outputChannels) ]
                       dataType:MPSDataTypeFloat32
                           name:[NSString stringWithFormat:@"%@/biases", label]];
@@ -892,8 +940,8 @@ static const NSInteger kMinSubBatchSize = 20;
                                            length:channelSize * sizeof(float)
                                      freeWhenDone:NO];
 
-  MPSGraphTensor *gammaTensor =
-      [self variableWithData:gammaData
+  MPSGraphTensor *gammaTensor = [self
+      weightVariableWithData:gammaData
                        shape:@[ @(channelSize) ]
                     dataType:MPSDataTypeFloat32
                         name:[NSString stringWithFormat:@"%@/gamma", label]];
@@ -902,8 +950,8 @@ static const NSInteger kMinSubBatchSize = 20;
                                           length:channelSize * sizeof(float)
                                     freeWhenDone:NO];
 
-  MPSGraphTensor *betaTensor =
-      [self variableWithData:betaData
+  MPSGraphTensor *betaTensor = [self
+      weightVariableWithData:betaData
                        shape:@[ @(channelSize) ]
                     dataType:MPSDataTypeFloat32
                         name:[NSString stringWithFormat:@"%@/beta", label]];
@@ -964,8 +1012,8 @@ static const NSInteger kMinSubBatchSize = 20;
                                            length:channelSize * sizeof(float)
                                      freeWhenDone:NO];
 
-  MPSGraphTensor *gammaTensor =
-      [self variableWithData:gammaData
+  MPSGraphTensor *gammaTensor = [self
+      weightVariableWithData:gammaData
                        shape:@[ @(channelSize) ]
                     dataType:MPSDataTypeFloat32
                         name:[NSString stringWithFormat:@"%@/gamma", label]];
@@ -1248,8 +1296,8 @@ static const NSInteger kMinSubBatchSize = 20;
                            length:outputSize * channelSize * sizeof(float)
                      freeWhenDone:NO];
 
-  MPSGraphTensor *weightTensor =
-      [self variableWithData:weightData
+  MPSGraphTensor *weightTensor = [self
+      weightVariableWithData:weightData
                        shape:@[ @(outputSize), @(channelSize) ]
                     dataType:parent.dataType
                         name:[NSString stringWithFormat:@"%@/weights", label]];
@@ -1370,8 +1418,8 @@ static const NSInteger kMinSubBatchSize = 20;
                                   sizeof(float)
                      freeWhenDone:NO];
 
-  MPSGraphTensor *encodingTensor =
-      [self variableWithData:encodingData
+  MPSGraphTensor *encodingTensor = [self
+      weightVariableWithData:encodingData
                        shape:shape
                     dataType:MPSDataTypeFloat32
                         name:[NSString stringWithFormat:@"%@/weights", label]];
@@ -1470,8 +1518,8 @@ static const NSInteger kMinSubBatchSize = 20;
                    length:[parent sizeOfDimensionsFrom:@1] * sizeof(float)
              freeWhenDone:NO];
 
-  MPSGraphTensor *weightsTensor =
-      [self variableWithData:weightsData
+  MPSGraphTensor *weightsTensor = [self
+      weightVariableWithData:weightsData
                        shape:@[ parent.shape[2], parent.shape[1] ]
                     dataType:MPSDataTypeFloat32
                         name:[NSString stringWithFormat:@"%@/weights", label]];


### PR DESCRIPTION
Adds an opt-in half-precision compute path for the Metal MPSGraph transformer, enabled with `METALFISH_METAL_FP16=1` (default stays FP32, so default behavior and the search/UCI contract are unchanged).

## How it works
- Weights are converted to FP16 on graph build (host float→half), kept alive for the graph's lifetime.
- The transformer body computes in FP16; the value/policy/moves-left heads are cast back to FP32 before decode.
- Inputs are still fed as FP32 and the bit-unpack/expansion math stays FP32; only the body runs in half precision.
- `network_info` now reports the active precision (FP32/FP16).

## Measured (Apple M2 Max, BT4-1024x15x32h, batch 1)
- **~14% faster per eval**: 9.3 → 8.1 ms.
- **Near-identical outputs**: value Δ~2e-5, top policy logit Δ~3e-4, same best move and top-5 ordering.

## Why opt-in (not default)
FP16's small precision difference can change move selection on borderline positions — pure-MCTS Bratko-Kopec is 23/24 under FP16 vs 24/24 under FP32. Since it perturbs move selection, it stays opt-in pending large-scale (Lichess) validation before any change of default.