### PR TITLE
Compile CUDA null-executor smoke harness for tests only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,7 +300,6 @@ if(USE_CUDA)
       src/nn/cuda/cuda_execution_tape.cpp
       src/nn/cuda/cuda_executor.cpp
       src/nn/cuda/cuda_network.cpp
-      src/nn/cuda/cuda_null_executor_smoke.cpp
       src/nn/cuda/cuda_output_mapping.cpp
       src/nn/cuda/cuda_plan_analysis.cpp
       src/nn/cuda/cuda_attention_plan.cpp
@@ -449,6 +448,13 @@ if(BUILD_TESTS)
     ${MCTS_SOURCES}
     ${HYBRID_SOURCES}
     ${NN_SOURCES})
+  # The CUDA null-executor smoke harness is exercised only by
+  # test_mcts_module.cpp, so it is compiled into the test target rather than
+  # shipped in the production engine library.
+  if(USE_CUDA)
+    target_sources(metalfish_tests
+                   PRIVATE src/nn/cuda/cuda_null_executor_smoke.cpp)
+  endif()
   if(METALFISH_IPO_SUPPORTED)
     set_property(TARGET metalfish_tests
                  PROPERTY INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)


### PR DESCRIPTION
`src/nn/cuda/cuda_null_executor_smoke.cpp` (~2200 lines) implements `Run*Smoke` helpers that are called only by `tests/test_mcts_module.cpp`, but it lived in the shared `NN_SOURCES` list and was therefore compiled into the production engine library on CUDA builds.

This moves it from `NN_SOURCES` to the `metalfish_tests` target (`target_sources`, guarded by `USE_CUDA`), so the released engine no longer carries the smoke scaffolding. No engine/probe code references its symbols, so the engine, `metalfish_nn_probe`, and `test_nn_comparison` link unchanged; the test target still links the harness for `test_mcts_module.cpp`.

Metal build + unit tests pass locally; relying on the CUDA compile gate to confirm the CUDA build.