### PR TITLE
Add Contempt option (draw aversion) for AB and MCTS

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -159,8 +159,13 @@ void update_correction_history(const Position &pos, Stack *const ss,
   }
 }
 
-// Add a small random component to draw evaluations to avoid 3-fold blindness
-Value value_draw(size_t nodes) { return VALUE_DRAW - 1 + Value(nodes & 0x2); }
+// Add a small random component to draw evaluations to avoid 3-fold blindness.
+// `contempt` (centipawns) is subtracted so a draw is worth slightly less than
+// equality from the side-to-move's perspective, biasing a stronger engine to
+// keep playing for a win instead of acquiescing to a draw.
+Value value_draw(size_t nodes, int contempt = 0) {
+  return VALUE_DRAW - 1 + Value(nodes & 0x2) - Value(contempt);
+}
 Value value_to_tt(Value v, int ply);
 Value value_from_tt(Value v, int ply, int r50c);
 void update_pv(Move *pv, Move move, const Move *childPv);
@@ -292,6 +297,10 @@ void Search::Worker::iterative_deepening() {
   Color us = rootPos.side_to_move();
   double timeReduction = 1, totBestMoveChanges = 0;
   int delta, iterIdx = 0;
+
+  // Read contempt once per search so every draw evaluation (and TT entry) in
+  // this search is consistent. 0 = objective draws (default).
+  rootContempt = int(options["Contempt"]);
 
   // Allocate stack with extra size to allow access from (ss - 7) to (ss + 2):
   // (ss - 7) is needed for update_continuation_histories(ss - 1) which accesses
@@ -664,7 +673,7 @@ Value Search::Worker::search(Position &pos, Stack *ss, Value alpha, Value beta,
 
   // Check if we have an upcoming move that draws by repetition
   if (!rootNode && alpha < VALUE_DRAW && pos.upcoming_repetition(ss->ply)) {
-    alpha = value_draw(nodes);
+    alpha = value_draw(nodes, rootContempt);
     if (alpha >= beta)
       return alpha;
   }
@@ -707,8 +716,9 @@ Value Search::Worker::search(Position &pos, Stack *ss, Value alpha, Value beta,
     // Step 2. Check for aborted search and immediate draw
     if (threads.stop.load(std::memory_order_relaxed) || pos.is_draw(ss->ply) ||
         ss->ply >= MAX_PLY) [[unlikely]]
-      return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(pos)
-                                                  : value_draw(nodes);
+      return (ss->ply >= MAX_PLY && !ss->inCheck)
+                 ? evaluate(pos)
+                 : value_draw(nodes, rootContempt);
 
     // Step 3. Mate distance pruning. Even if we mate at the next move our score
     // would be at best mate_in(ss->ply + 1), but if alpha is already bigger
@@ -1511,7 +1521,7 @@ Value Search::Worker::qsearch(Position &pos, Stack *ss, Value alpha,
 
   // Check if we have an upcoming move that draws by repetition
   if (alpha < VALUE_DRAW && pos.upcoming_repetition(ss->ply)) {
-    alpha = value_draw(nodes);
+    alpha = value_draw(nodes, rootContempt);
     if (alpha >= beta)
       return alpha;
   }
@@ -1541,7 +1551,9 @@ Value Search::Worker::qsearch(Position &pos, Stack *ss, Value alpha,
 
   // Step 2. Check for an immediate draw or maximum ply reached
   if (pos.is_draw(ss->ply) || ss->ply >= MAX_PLY)
-    return (ss->ply >= MAX_PLY && !ss->inCheck) ? evaluate(pos) : VALUE_DRAW;
+    return (ss->ply >= MAX_PLY && !ss->inCheck)
+               ? evaluate(pos)
+               : value_draw(nodes, rootContempt);
 
   assert(0 <= ss->ply && ss->ply < MAX_PLY);
 

--- a/src/search/search.h
+++ b/src/search/search.h
@@ -305,6 +305,7 @@ private:
   int selDepth, nmpMinPly;
 
   Value optimism[COLOR_NB];
+  int rootContempt = 0; // centipawns subtracted from draw evals (avoid draws)
 
   Position rootPos;
   StateInfo rootState;

--- a/src/uci/engine.cpp
+++ b/src/uci/engine.cpp
@@ -94,6 +94,10 @@ Engine::Engine(std::optional<std::string> path)
   options.add("Skill Level", Option(20, 0, 20));
 
   options.add("Move Overhead", Option(10, 0, 5000));
+  // Draw aversion in centipawns (0 = objective). Positive values make the
+  // engine value a draw slightly below equality on both the AB and MCTS paths,
+  // so a stronger engine keeps playing for a win instead of repeating.
+  options.add("Contempt", Option(0, 0, 100));
 
   options.add("nodestime", Option(0, 0, 10000));
 

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -976,6 +976,14 @@ static MCTS::SearchParams make_mcts_config(Engine &engine,
   config.cpuct_factor_at_root = get_float_option(
       engine, "MCTSCPuctFactorAtRoot", config.cpuct_factor_at_root);
 
+  // Map the shared Contempt option (centipawns) onto the MCTS draw score in
+  // win units. Set draw_score directly (it is part of the network cache key,
+  // unlike params_.contempt) so a draw is valued below equality and MCTS keeps
+  // fighting. 0 = objective draws.
+  config.draw_score =
+      -static_cast<float>(static_cast<int>(engine.get_options()["Contempt"])) /
+      100.0f;
+
   config.fpu_absolute = engine.get_options()["MCTSFpuAbsolute"];
   config.fpu_absolute_at_root = engine.get_options()["MCTSFpuAbsoluteAtRoot"];
   config.fpu_value = get_float_option(engine, "MCTSFpuValue", config.fpu_value);


### PR DESCRIPTION
Adds a `Contempt` UCI option (centipawns, **default 0 = byte-identical no-op**) that values a draw slightly below equality from the side-to-move's perspective, so a stronger engine keeps playing for a win instead of repeating.

Motivation: across 346 real Lichess games the engine is 70W–2L–271D — a 97% decisive win rate but a 79% draw rate (it is stronger than its opponents yet settles for draws). This wires up the (previously dormant) draw-aversion mechanism so that behavior can be tuned and validated.

**How it works**
- **AB**: `value_draw()` subtracts contempt at the *choosable* draw sites only — upcoming-repetition and immediate-draw in both search and qsearch. Forced stalemate, root no-moves, and tablebase/rule50 draws stay objective.
- **MCTS**: the option maps to `draw_score` (already part of the network cache key), so cached evaluations remain correct.
- Read once per AB search for consistency across TT entries.

**Safety**
- Default 0 reproduces current behavior exactly (build clean, unit tests pass).
- AB contempt shifts the score the hybrid coordinator consumes only on draw-PVs and by at most the contempt magnitude; its arbitration thresholds are tuned at contempt 0, so AB contempt should stay small (≤ ~20cp) until the coordinator is changed to consume an objective score. Tuning/validation will be done via the Lichess bot before changing any default.