### PR TITLE
Hybrid: thin-regime MCTS override (default off)

### DIFF
--- a/src/hybrid/hybrid_search.cpp
+++ b/src/hybrid/hybrid_search.cpp
@@ -1554,6 +1554,32 @@ bool HybridMCTSVisitEvidenceSane(uint64_t mcts_playouts, uint64_t mcts_evals,
   return best_visits <= best_eval_limit && root_visits <= root_eval_limit;
 }
 
+// Thin-regime MCTS rescue. When the MCTS tree is small (few nodes -- fast time
+// controls or time pressure) but MCTS is shape-confident on one move and AB has
+// not tactically refuted it, trust MCTS. In the thin regime the neural
+// policy/value dominates a shallow alpha-beta (e.g. at 50 nodes pure MCTS
+// solves Bratko-Kopec 24/24 vs AB 8/24); once the tree is thick (>= 1024 nodes)
+// this guard disables itself so AB's deep search and the existing arbitration
+// prevail (the hybrid already scores 24/24 at full movetime). Pure and
+// unit-tested; the AB tactical veto (ab_root_rejects_mcts) is always honored
+// first.
+bool HybridThinMCTSConfidentOverride(bool enabled, bool visit_evidence_sane,
+                                     bool ab_root_rejects_mcts,
+                                     uint64_t mcts_total_current_nodes,
+                                     uint32_t mcts_best_current_visits,
+                                     float visit_share, float root_q_gap,
+                                     int eval_delta) {
+  if (!enabled || !visit_evidence_sane || ab_root_rejects_mcts)
+    return false;
+  if (mcts_total_current_nodes >= 1024)
+    return false;
+  if (mcts_best_current_visits < 16)
+    return false;
+  if (visit_share < 0.70f || root_q_gap < 0.50f)
+    return false;
+  return eval_delta >= -20;
+}
+
 bool HybridANEConfirmedMCTSOverride(bool enabled, bool ane_agrees_mcts,
                                     bool fixed_budget, bool visit_evidence_sane,
                                     uint64_t mcts_root_visits,
@@ -5126,14 +5152,19 @@ Move ParallelHybridSearch::make_final_decision() {
       }
     }
   }
+  const bool thin_mcts_confident_override = HybridThinMCTSConfidentOverride(
+      config_.thin_mcts_confident_override, mcts_visit_evidence_sane,
+      ab_root_rejects_mcts, mcts_total_current_nodes, mcts_current_visits,
+      visit_share, root_q_gap, eval_delta);
   const bool mcts_override_allowed =
-      low_node_mcts_primary_ready || !ab_root_rejects_mcts ||
-      ane_confirmed_mcts_override || pawn_only_ane_mcts_override ||
-      pawn_only_mcts_override || ane_q_supported_root_override ||
-      mcts_short_root_tactical || mcts_verified_hint_support ||
-      mcts_compact_fixed_budget || mcts_compact_pawn_endgame ||
-      mcts_ab_lowerbound_confirmed || mcts_low_node_root_confidence ||
-      mcts_ultra_low_node_root_confidence || mcts_compact_clear_preference ||
+      thin_mcts_confident_override || low_node_mcts_primary_ready ||
+      !ab_root_rejects_mcts || ane_confirmed_mcts_override ||
+      pawn_only_ane_mcts_override || pawn_only_mcts_override ||
+      ane_q_supported_root_override || mcts_short_root_tactical ||
+      mcts_verified_hint_support || mcts_compact_fixed_budget ||
+      mcts_compact_pawn_endgame || mcts_ab_lowerbound_confirmed ||
+      mcts_low_node_root_confidence || mcts_ultra_low_node_root_confidence ||
+      mcts_compact_clear_preference ||
       mcts_cross_root_confidence_fixed_budget ||
       mcts_root_confidence_reject_override || mcts_reused_root_confidence ||
       mcts_root_reject_low_material_push || mcts_root_reject_rook_pawn_push ||
@@ -5207,6 +5238,9 @@ Move ParallelHybridSearch::make_final_decision() {
     } else if (low_node_mcts_primary_ready) {
       choose_mcts = true;
       reason = "low_node_mcts_primary";
+    } else if (thin_mcts_confident_override) {
+      choose_mcts = true;
+      reason = "thin_mcts_confident";
     } else if (ane_confirmed_mcts_override) {
       choose_mcts = true;
       reason = "ane_confirmed_mcts";

--- a/src/hybrid/hybrid_search.h
+++ b/src/hybrid/hybrid_search.h
@@ -214,6 +214,9 @@ struct ParallelHybridConfig {
   int ab_candidate_verify_ms = 120;
   int ab_candidate_verify_count = 5;
   bool root_pawn_lever_tiebreak = true;
+  // Thin-regime MCTS rescue (default off pending game validation): route to a
+  // shape-confident MCTS move when its tree is thin and AB has not refuted it.
+  bool thin_mcts_confident_override = false;
   bool ane_root_probe = false;
   bool ane_root_hints = false;
   bool ane_confirm_mcts_override = false;
@@ -622,6 +625,13 @@ bool HybridMCTSBishopEndgameRetreatOverride(
 
 bool HybridMCTSVisitEvidenceSane(uint64_t mcts_playouts, uint64_t mcts_evals,
                                  uint64_t root_visits, uint32_t best_visits);
+
+bool HybridThinMCTSConfidentOverride(bool enabled, bool visit_evidence_sane,
+                                     bool ab_root_rejects_mcts,
+                                     uint64_t mcts_total_current_nodes,
+                                     uint32_t mcts_best_current_visits,
+                                     float visit_share, float root_q_gap,
+                                     int eval_delta);
 
 bool HybridANEConfirmedMCTSOverride(bool enabled, bool ane_agrees_mcts,
                                     bool fixed_budget, bool visit_evidence_sane,

--- a/src/uci/engine.cpp
+++ b/src/uci/engine.cpp
@@ -166,6 +166,7 @@ Engine::Engine(std::optional<std::string> path)
   options.add("HybridABCandidateVerifyMs", Option(240, 0, 1000));
   options.add("HybridABCandidateVerifyCount", Option(5, 1, 10));
   options.add("HybridRootPawnLeverTieBreak", Option(true));
+  options.add("HybridThinMCTSOverride", Option(false));
   options.add("HybridANERootProbe", Option(false));
   options.add("HybridANERootHints", Option(false));
   options.add("HybridANEConfirmMCTSOverride", Option(false));

--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -1218,6 +1218,8 @@ make_hybrid_config(Engine &engine, const std::string &nn_weights,
       static_cast<int>(engine.get_options()["HybridABCandidateVerifyCount"]);
   config.root_pawn_lever_tiebreak =
       engine.get_options()["HybridRootPawnLeverTieBreak"];
+  config.thin_mcts_confident_override =
+      engine.get_options()["HybridThinMCTSOverride"];
   config.ane_root_probe = engine.get_options()["HybridANERootProbe"];
   config.ane_root_hints = engine.get_options()["HybridANERootHints"];
   config.ane_confirm_mcts_override =

--- a/tests/test_hybrid.cpp
+++ b/tests/test_hybrid.cpp
@@ -2029,6 +2029,34 @@ void test_hybrid_config() {
     EXPECT(tc, !HybridMCTSVisitEvidenceSane(0, 0, 10, 1));
   }
   {
+    TestCase tc("Thin-regime confident MCTS override stays tightly gated");
+    // Confident, thin tree, AB does not refute -> fires.
+    EXPECT(tc, HybridThinMCTSConfidentOverride(true, true, false, 200, 80,
+                                               0.80f, 0.60f, 10));
+    // Disabled (default) -> never fires; behavior stays byte-identical.
+    EXPECT(tc, !HybridThinMCTSConfidentOverride(false, true, false, 200, 80,
+                                                0.80f, 0.60f, 10));
+    // Thick tree (>=1024 nodes) -> deep AB / existing arbitration prevails.
+    EXPECT(tc, !HybridThinMCTSConfidentOverride(true, true, false, 1024, 80,
+                                                0.80f, 0.60f, 10));
+    // AB tactical veto always wins.
+    EXPECT(tc, !HybridThinMCTSConfidentOverride(true, true, true, 200, 80,
+                                                0.80f, 0.60f, 10));
+    // Not visit-concentrated, or value not separated -> no fire.
+    EXPECT(tc, !HybridThinMCTSConfidentOverride(true, true, false, 200, 80,
+                                                0.65f, 0.60f, 10));
+    EXPECT(tc, !HybridThinMCTSConfidentOverride(true, true, false, 200, 80,
+                                                0.80f, 0.40f, 10));
+    // Visit noise floor and contradicted value -> no fire.
+    EXPECT(tc, !HybridThinMCTSConfidentOverride(true, true, false, 200, 8,
+                                                0.80f, 0.60f, 10));
+    EXPECT(tc, !HybridThinMCTSConfidentOverride(true, true, false, 200, 80,
+                                                0.80f, 0.60f, -50));
+    // Insane visit evidence -> no fire.
+    EXPECT(tc, !HybridThinMCTSConfidentOverride(true, false, false, 200, 80,
+                                                0.80f, 0.60f, 10));
+  }
+  {
     TestCase tc("AB root rejection blocks low-effort MCTS blunders");
 
     EXPECT(tc,


### PR DESCRIPTION
Targets the one place the hybrid is measurably worse than its best component: the **thin-tree regime**. At fixed nodes=50, pure MCTS solves Bratko-Kopec 24/24 while pure AB and the current hybrid get only 8/24 — in a shallow search the neural policy/value dominates alpha-beta, but the hybrid collapses onto AB. The existing low-node MCTS-primary escape only fires in fixed-**node** benchmark mode (`limits.nodes>0`), never on a real clock, so fast time controls / time pressure get no protection. (At full movetime the tree is thick and the hybrid already scores 24/24, so there is no movetime gap to fix.)

Adds `HybridThinMCTSConfidentOverride` — a pure, unit-tested predicate that routes to the MCTS move only when **all** hold: MCTS tree is thin (`< 1024` current nodes), visit-concentrated (share ≥ 0.70 and root Q-gap ≥ 0.50), AB has **not** tactically rejected it (`ab_root_rejects_mcts` is honored first), and its value is not contradicted by the AB score.

**Safety:** gated behind the new `HybridThinMCTSOverride` UCI option, **default false** → byte-identical default behavior. At thick trees (movetime) the predicate disables itself, so the 24/24 movetime result is preserved. Additive — deletes none of the existing arbitration. To be enabled only after cutechess + Lichess game validation at fast/thin time controls.