### PR TITLE
Fix NEON SqrClippedReLU to clamp activations at 127

### DIFF
--- a/src/eval/nnue/layers/sqr_clipped_relu.h
+++ b/src/eval/nnue/layers/sqr_clipped_relu.h
@@ -106,11 +106,15 @@ public:
       int16x8_t words0 = vcombine_s16(r0, r1);
       int16x8_t words1 = vcombine_s16(r2, r3);
 
-      // Pack int16 -> uint8 (saturate)
-      uint8x8_t bytes0 = vqmovun_s16(words0);
-      uint8x8_t bytes1 = vqmovun_s16(words1);
-      vst1q_u8(reinterpret_cast<uint8_t *>(&out[i]),
-               vcombine_u8(bytes0, bytes1));
+      // Pack int16 -> int8 with SIGNED saturation so activations clamp at 127,
+      // matching the scalar min(127, ...) path below and the SSE2
+      // _mm_packs_epi16 path above. The squared values are non-negative, so
+      // signed saturation yields [0, 127] and the int8/uint8 bit patterns are
+      // identical. (vqmovun_s16 saturates to [0, 255], which over-saturates any
+      // activation >= 127 and corrupts the NNUE eval on aarch64.)
+      int8x8_t bytes0 = vqmovn_s16(words0);
+      int8x8_t bytes1 = vqmovn_s16(words1);
+      out[i] = vcombine_s8(bytes0, bytes1);
     }
     constexpr IndexType Start = NumChunks * 16;
 


### PR DESCRIPTION
## Summary

The aarch64 NEON path of `SqrClippedReLU::propagate` narrowed the squared-clipped-ReLU output with `vqmovun_s16` (unsigned saturate to `[0, 255]`) instead of a signed saturate to `[0, 127]`.

The other two implementations of the same function clamp at 127:
- scalar: `std::min(127ll, (x*x) >> 19)`
- SSE2: `_mm_packs_epi16` (signed → int8, max 127)

So the NEON branch was the lone outlier. For any `fc_0` output with `|x| >= 8192`, it produced activations of `128`–`255` instead of `127`, which then fed corrupted inputs into the next affine layer. Because Apple Silicon builds with `-DUSE_NEON=8`, this silently diverged the CPU NNUE evaluation on the primary platform from the x86/scalar reference.

## Fix

Narrow with `vqmovn_s16` (signed) and store as `int8` (the `out` pointer is already `int8x16_t*`). Squared values are non-negative, so the result is `[0, 127]` and the int8/uint8 bit patterns are identical — matching the scalar and SSE2 paths exactly.

## Validation

- **Intrinsic-level parity** (exact intrinsics from the code, run on Apple Silicon): current `vqmovun` diverges from the scalar reference on 6/8 sampled `fc_0` magnitudes (all `|x| >= 8192`); the fixed `vqmovn` has **0 divergences**.
- **Real eval impact**: over 90 real midgame positions, the static NNUE eval changed on 2 positions, by up to **2.25 pawns** (e.g. `-2.75 → -0.50`) — confirming the over-saturation corrupted real evaluations. Rare, but a large error when it fires.
- **No regression**: full C++ unit suite passes (`core`, `search`, `eval_gpu`, `mcts`, `hybrid` — hybrid 63/63); `tests/testing.py --quick` perft + UCI smoke 18/18.