### PR TITLE
Harden UCI spin-option parsing against malformed input

### DIFF
--- a/src/uci/uci.cpp
+++ b/src/uci/uci.cpp
@@ -1757,8 +1757,13 @@ void UCIEngine::mcts_mt_go(std::istringstream &is) {
   std::istringstream option_args(args);
   while (option_args >> token) {
     if (token.find("threads=") == 0) {
-      num_threads = std::stoi(token.substr(8));
-      explicit_threads_arg = true;
+      try {
+        num_threads = std::stoi(token.substr(8));
+        explicit_threads_arg = true;
+      } catch (...) {
+        // Ignore a malformed threads= argument and keep the option default
+        // rather than throwing out of the command loop.
+      }
     }
   }
 

--- a/src/uci/ucioption.cpp
+++ b/src/uci/ucioption.cpp
@@ -123,9 +123,26 @@ Option &Option::operator=(const std::string &v) {
   assert(!type.empty());
 
   if ((type != "button" && type != "string" && v.empty()) ||
-      (type == "check" && v != "true" && v != "false") ||
-      (type == "spin" && (std::stoi(v) < min || std::stoi(v) > max)))
+      (type == "check" && v != "true" && v != "false"))
     return *this;
+
+  // Validate spin range without throwing. Values can arrive from the console,
+  // not just a GUI, so a non-numeric or oversized token (e.g. "Threads value
+  // abc") must be rejected rather than letting std::stoi throw out of the UCI
+  // command loop and terminate the engine.
+  if (type == "spin") {
+    int parsed = 0;
+    try {
+      std::size_t consumed = 0;
+      parsed = std::stoi(v, &consumed);
+      if (consumed != v.size())
+        return *this;
+    } catch (...) {
+      return *this;
+    }
+    if (parsed < min || parsed > max)
+      return *this;
+  }
 
   if (type == "combo") {
     OptionsMap comboMap; // To have case insensitive compare


### PR DESCRIPTION
## Summary

`Option::operator=` validated spin bounds with an unguarded `std::stoi(v)`, and the `mcts` debug command parsed `threads=<x>` the same way. The comment on `operator=` already notes that values can arrive from the console, but non-numeric or oversized input (e.g. `setoption name Threads value abc`) threw `std::invalid_argument` / `std::out_of_range` straight out of the UCI command loop, terminating the engine.

## Fix

Parse spin values defensively in both sites: reject anything unparseable, with trailing characters, or out of range instead of throwing. The engine now ignores malformed option input and keeps running.

## Validation

- Repro before/after: a session sending `setoption name Threads value abc`, `Hash value notanumber`, oversized values, then a valid `Threads value 4` — the engine now returns `readyok` and plays normally (`e2e4` from startpos at depth 14) instead of aborting.
- Full C++ unit suite passes (`core`, `search`, `eval_gpu`, `mcts`, `hybrid`).
- No behavioral change for well-formed input (valid values parse and apply exactly as before).