### PR TITLE
Prepare v1.0.0 launch: version, docs accuracy, packaging

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # MetalFish Copilot Instructions
 
-MetalFish v0.1.0-alpha is a hybrid UCI chess engine. Treat the Hybrid engine
+MetalFish v1.0.0 is a hybrid UCI chess engine. Treat the Hybrid engine
 as the primary product surface.
 
 ## Platform Surface

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,8 @@ jobs:
         with:
           files: metalfish-${{ github.ref_name }}-macos-arm64.tar.gz
           draft: false
-          prerelease: true
+          # Stable for plain tags (v1.0.0); prerelease for suffixed tags (v1.0.0-rc1).
+          prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cuda-release.yml
+++ b/.github/workflows/cuda-release.yml
@@ -93,7 +93,8 @@ jobs:
             cuda-release/packages/*
             cuda-release/cuda-release-artifacts-manifest.json
           draft: false
-          prerelease: true
+          # Stable for plain tags (v1.0.0); prerelease for suffixed tags (v1.0.0-rc1).
+          prerelease: ${{ contains(steps.release-inputs.outputs.tag_name, '-') }}
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v1.0.0
+
+First stable release.
+
+- NNUE evaluation correctness fix on Apple Silicon: the NEON
+  squared-clipped-ReLU now clamps activations at 127, matching the scalar and
+  SSE2 paths. This fixes an unsigned-saturation bug that diverged the CPU eval
+  from the reference for large activations.
+- Hardened UCI option parsing: malformed spin values (e.g. a non-numeric
+  `Threads`) are rejected instead of throwing out of the command loop.
+- Documentation accuracy pass: honest strength characterization (playing
+  strength comes from the alpha-beta + NNUE search; the GPU transformer MCTS is
+  a research/diagnostic path, not a strength multiplier), corrected option
+  defaults, prebuilt-binary install instructions, and explicit Stockfish/Lc0
+  acknowledgements.
+- Release packaging: tagged GitHub releases are marked stable for plain version
+  tags and prerelease only for suffixed tags (e.g. `-rc1`).
+
 ## v0.1.0-alpha
 
 First public alpha release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to MetalFish
+
+Thanks for your interest in MetalFish. The project is licensed under GPL-3.0 and
+contributions are accepted under the same license.
+
+## Prerequisites
+
+Download the network files before building (CMake copies the NNUE files into
+`build/` at configure time, so they must exist first):
+
+```bash
+python3 tools/download_engine_networks.py --dest networks
+```
+
+## Build
+
+macOS (Apple Silicon — the primary path):
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DUSE_METAL=ON
+cmake --build build --target metalfish metalfish_tests -j"$(sysctl -n hw.ncpu)"
+```
+
+For Linux/Windows CUDA, see the README and `docs/cross_platform_backend_plan.md`.
+
+## Test
+
+```bash
+./build/metalfish_tests            # C++ unit suite: core search eval_gpu mcts hybrid
+python3 tests/testing.py --quick   # UCI protocol + perft smoke
+python3 tests/test_lichess_bot.py
+python3 tests/test_lichess_puzzle_runner.py
+```
+
+## Lint / format
+
+`pre-commit` enforces clang-format (C++), black + isort (`--profile=black`,
+Python), cmake-format, and check-yaml. Run it before committing:
+
+```bash
+pre-commit run --all-files
+```
+
+## Pull requests
+
+- Keep changes focused — one logical change per PR.
+- Run the unit suite and `pre-commit` locally; CI must be green before merge.
+- For search/eval behavior changes, include validation evidence. The engine is
+  already strong, so gains are incremental and need low-noise measurement
+  (cutechess tournaments and/or the Lichess bot), not single positions.
+- Strength claims must follow the README "Benchmarking Policy" and "Strength
+  Claims" sections — no "stronger than X" wording without large-scale testing.
+
+## Acknowledgements
+
+MetalFish derives from Stockfish (alpha-beta search and NNUE evaluation) and is
+Lc0-compatible (MCTS and the BT4 transformer), both GPL-3.0. See the README
+"Acknowledgements" section.

--- a/README.md
+++ b/README.md
@@ -9,19 +9,24 @@ Current platform surface:
 
 | Platform | Backend | Status |
 | --- | --- | --- |
-| macOS Apple Silicon | Metal/MPSGraph + CPU NNUE | Primary v0.1.0-alpha release path |
+| macOS Apple Silicon | Metal/MPSGraph + CPU NNUE | Primary release path (v1.0.0) |
 | Linux x86-64 NVIDIA | CUDA + CPU NNUE | Parity-gated in CI/GCP runtime gates |
 | Windows x86-64 NVIDIA | CUDA + CPU NNUE | MSVC/NVCC compile gate plus L4 runtime gate |
 | Portable Linux/Windows CPU | CPU AB and transformer fallback | Correctness/fallback, not a strength target |
 
 ## Project Status
 
-MetalFish is experimental engine research, not a Stockfish replacement claim.
-The standalone alpha-beta search is Stockfish-family search engineering; the
-standalone MCTS path is an Lc0-compatible transformer search implementation.
-The main research contribution is the hybrid runtime: CPU NNUE alpha-beta and
-GPU transformer MCTS search the same position concurrently, exchange root-level
-signals, and use a coordinator to select the final move.
+MetalFish 1.0.0 is a working UCI engine, not a Stockfish replacement claim. Its
+playing strength comes from the CPU alpha-beta search with a Stockfish-family
+NNUE evaluation; the standalone MCTS path is an Lc0-compatible transformer
+search that loads BT4 weights.
+
+The project's research contribution is the hybrid runtime: CPU NNUE alpha-beta
+and GPU transformer MCTS search the same position concurrently, exchange
+root-level signals, and a coordinator selects the final move. In practice the
+coordinator defers to the alpha-beta move when the GPU MCTS is not clearly
+better, so the hybrid's strength tracks its alpha-beta component — the GPU side
+is a research/diagnostic path, not a strength multiplier.
 
 ## Engine Modes
 
@@ -95,20 +100,22 @@ python3 tools/lichess_puzzle_runner.py \
   --threads auto --hash-mb 4096 --movetime-ms 1000
 ```
 
-Latest local tactical run, M2 Max, 5 seconds per position, generated
-2026-05-20 with `--threads auto --hash auto`:
+The 24-position Bratko-Kopec suite is a small tactical smoke test, useful for
+regression tracking but far too small and noisy to rank engines or estimate
+Elo. On an M2 Max at 5s/position the MetalFish configurations and references all
+land in the low-20s out of 24 — at the resolution limit of a 24-position suite.
+Two points matter for an honest reading:
 
-| Engine | Score | Completed | Notes |
-| --- | ---: | ---: | --- |
-| MetalFish Hybrid | 24/24 | 24/24 | 1 MCTS worker + 7 AB workers, BT4 weights |
-| Stockfish reference | 21/24 | 24/24 | 8 workers, 4096 MB hash |
-| MetalFish AB | 20/24 | 24/24 | 8 workers, 4096 MB hash |
-| MetalFish MCTS | 20/24 | 24/24 | BT4 weights, one Apple MCTS worker, strength KLD profile |
-| Lc0 with BT4 weights | 17/24 | 24/24 | Metal backend, `Threads=8`, `Temperature=0` |
+- **The hybrid's tactical score tracks its alpha-beta + NNUE component.** On the
+  committed-config run the GPU transformer performed zero evaluations on every
+  solved position (`nn_evals=0` in `results/paper_tactical.json`), i.e. the
+  result came from the CPU search, not the GPU MCTS. Hybrid-vs-AB differences on
+  this suite are not GPU strength.
+- Per-position differences at this sample size are dominated by worker-count and
+  run-to-run variance, not engine strength.
 
-In this run, Hybrid solved BK.07, BK.09, BK.11, BK.17, and BK.22 where at
-least one standalone component or reference engine missed. This is a tactical
-suite result only; it is not an Elo estimate.
+For any actual strength claim, use a large cutechess tournament with the fair
+resource policy below — never this suite.
 
 A forced full-worker pure-MCTS stress run (`MCTSMaxThreads=8`) is not a
 strength profile for the current backend. It previously scored 12/24 and timed
@@ -116,8 +123,8 @@ out on BK.24, which is why pure MCTS now caps Apple workers unless
 `MCTSParallelSearch=true` is set.
 
 MetalFish's pure-MCTS strength profile intentionally uses a small
-`MCTSMinimumKLDGainPerNode=0.00005` tactical stopper and
-`PureMCTSSmartPruningFactor=0.0`. This keeps pure MCTS from freezing low-root
+`MCTSMinimumKLDGainPerNode=0.00005` tactical stopper and the default
+`PureMCTSSmartPruningFactor=0.5`. This keeps pure MCTS from freezing low-root
 alternatives too early while leaving Hybrid's MCTS worker on its separate
 hybrid profile. For an exact Lc0-style KLD-off diagnostic
 comparison, run:
@@ -205,6 +212,25 @@ curl -L -o networks/BT4-1024x15x32h-swa-6147500.pb.gz \
 gzip -dc networks/BT4-1024x15x32h-swa-6147500.pb.gz \
   > networks/BT4-1024x15x32h-swa-6147500.pb
 ```
+
+## Install (prebuilt macOS binary)
+
+Each tagged release publishes a macOS arm64 tarball
+(`metalfish-<tag>-macos-arm64.tar.gz`). It contains the engine binary but not
+the network files, which must be fetched separately:
+
+```bash
+tar -xzf metalfish-v1.0.0-macos-arm64.tar.gz
+python3 tools/download_engine_networks.py --dest networks
+./metalfish
+# then, over UCI:
+#   setoption name UseHybridSearch value true
+#   setoption name NNWeights value networks/BT4-1024x15x32h-swa-6147500.pb
+```
+
+The two Stockfish `nn-*.nnue` files must be discoverable from the working
+directory (the downloader places them in `networks/`; pass the directory via the
+`EvalFile`/`EvalFileSmall` UCI options if you run the binary from elsewhere).
 
 ## Build
 
@@ -380,6 +406,20 @@ src/uci/       UCI protocol
 tests/         Unit, UCI, ponder, and benchmark tests
 tools/         Lichess bot, puzzle runner, books, Syzygy, tournaments
 ```
+
+## Acknowledgements
+
+MetalFish builds on outstanding open-source work, all under GPL-3.0:
+
+- **Stockfish** (https://github.com/official-stockfish/Stockfish) — the
+  alpha-beta search, transposition table, and NNUE evaluation are derived from
+  Stockfish, and the default `nn-*.nnue` networks are Stockfish networks.
+- **Leela Chess Zero / Lc0** (https://github.com/LeelaChessZero/lc0) — the MCTS
+  and the BT4 transformer input/policy encoding are Lc0-compatible, and the
+  `BT4-1024x15x32h` network is an Lc0 network.
+
+These projects are GPL-3.0, the same license MetalFish uses; see their
+repositories for their respective copyright holders.
 
 ## License
 

--- a/docs/cross_platform_backend_plan.md
+++ b/docs/cross_platform_backend_plan.md
@@ -171,7 +171,7 @@ python3 tools/dispatch_cuda_release_artifacts.py \
   --ref main \
   --gate-ref main \
   --expected-sha <commit-sha> \
-  --tag-name v0.1.0-alpha \
+  --tag-name v1.0.0 \
   --attach-to-release
 ```
 
@@ -181,7 +181,7 @@ runtime root instead of GitHub run IDs:
 ```bash
 python3 tools/dispatch_cuda_release_artifacts.py \
   --direct-runtime-root results/cuda_runtime_direct/<sha> \
-  --tag-name v0.1.0-alpha \
+  --tag-name v1.0.0 \
   --out-dir results/cuda_release_artifacts/<sha>
 ```
 

--- a/src/core/misc.cpp
+++ b/src/core/misc.cpp
@@ -28,7 +28,7 @@ namespace MetalFish {
 
 namespace {
 
-constexpr std::string_view version = "0.1.0-alpha";
+constexpr std::string_view version = "1.0.0";
 
 // Our fancy logging facility. The trick here is to replace cin.rdbuf() and
 // cout.rdbuf() with two Tie objects that tie cin and cout to a file stream. We

--- a/src/eval/nnue/network.cpp
+++ b/src/eval/nnue/network.cpp
@@ -178,9 +178,11 @@ void Network<Arch, Transformer>::verify(
           "The UCI option EvalFile might need to specify the full path, "
           "including the directory name, to the network file.";
       std::string msg4 =
-          "The default net can be downloaded from: "
-          "https://github.com/NripeshN/MetalFish/releases/download/nnue/" +
-          std::string(evalFile.defaultName);
+          "The default nets can be fetched with "
+          "'python3 tools/download_engine_networks.py --dest networks' "
+          "(NNUE files are mirrored at "
+          "https://tests.stockfishchess.org/api/nn/" +
+          std::string(evalFile.defaultName) + ").";
       std::string msg5 = "The engine will be terminated now.";
 
       std::string msg = "ERROR: " + msg1 + '\n' + "ERROR: " + msg2 + '\n' +

--- a/tests/test_nn_backend_artifacts.py
+++ b/tests/test_nn_backend_artifacts.py
@@ -2117,9 +2117,9 @@ def test_cuda_release_artifact_helpers_validate_packages_and_manifests() -> None
         expect(
             "release package tag",
             cuda_release.release_package_name(
-                linux_package, tag_name="v0.1.0-alpha", platform="linux-x86_64-cuda"
+                linux_package, tag_name="v1.0.0", platform="linux-x86_64-cuda"
             )
-            == "metalfish-v0.1.0-alpha-linux-x86_64-cuda.tar.gz",
+            == "metalfish-v1.0.0-linux-x86_64-cuda.tar.gz",
         )
 
 
@@ -2259,7 +2259,7 @@ def test_cuda_release_artifacts_promote_direct_runtime_root() -> None:
                     "--out-dir",
                     str(out_dir),
                     "--tag-name",
-                    "v0.1.0-alpha",
+                    "v1.0.0",
                 ]
             )
             == 0,
@@ -2283,9 +2283,7 @@ def test_cuda_release_artifacts_promote_direct_runtime_root() -> None:
         expect(
             "direct release package",
             (
-                out_dir
-                / "packages"
-                / "metalfish-v0.1.0-alpha-windows-x86_64-msvc-cuda.zip"
+                out_dir / "packages" / "metalfish-v1.0.0-windows-x86_64-msvc-cuda.zip"
             ).is_file(),
         )
 
@@ -2441,7 +2439,7 @@ def test_cuda_release_artifacts_reject_direct_runtime_commit_drift() -> None:
                     "--out-dir",
                     str(root / "release"),
                     "--tag-name",
-                    "v0.1.0-alpha",
+                    "v1.0.0",
                 ]
             )
         except ValueError as exc:
@@ -2474,7 +2472,7 @@ def test_cuda_release_dispatch_direct_root_uses_manifest_sha_default() -> None:
                         "--out-dir",
                         str(out_dir),
                         "--tag-name",
-                        "v0.1.0-alpha",
+                        "v1.0.0",
                     ]
                 )
                 == 0,


### PR DESCRIPTION
Readies the repo for a credible, honest v1.0.0 launch.

## Version cutover
- `0.1.0-alpha` → `1.0.0` in `src/core/misc.cpp` (drives the UCI `id name`), mirrored across README, CHANGELOG, copilot-instructions, docs examples, and the release-artifact naming tests. Verified: `id name MetalFish 1.0.0`.

## Documentation accuracy (honesty)
- Reframe the Bratko-Kopec table as a small, noisy tactical **smoke test**, not an engine ranking. The hybrid's tactical score tracks its AB+NNUE component — the committed-config run records `nn_evals=0`, i.e. the GPU MCTS did not contribute to those solves.
- State plainly in Project Status that the GPU hybrid is a **research/diagnostic path, not a strength multiplier** (the coordinator defers to AB when MCTS isn't clearly better).
- Fix the documented `PureMCTSSmartPruningFactor` default (`0.5`, matching `engine.cpp`).
- Add a **prebuilt-binary install** section and a **Stockfish/Lc0 acknowledgements** section.

## Packaging / metadata
- CHANGELOG `v1.0.0` entry; new `CONTRIBUTING.md`.
- NNUE-missing error now points at `tools/download_engine_networks.py` instead of a dead URL.
- GitHub releases are stable for plain tags (`v1.0.0`) and prerelease only for suffixed tags (`v1.0.0-rc1`) — `ci.yml`, `cuda-release.yml`.

## Validation
- Release build succeeds; `id name MetalFish 1.0.0`.
- `tests/test_nn_backend_artifacts.py` passes (`OK`).
- `pre-commit run` clean on all touched files.

Note: a separate, larger item — restoring upstream Stockfish/Lc0 copyright attribution in per-file headers for GPL-3.0 compliance — is tracked separately as it touches every source file.