### PR TITLE
Fix FP16 promotion-policy weights reinterpreted as half

### DIFF
--- a/src/nn/metal/mps/NetworkGraph.mm
+++ b/src/nn/metal/mps/NetworkGraph.mm
@@ -1296,10 +1296,14 @@ static const NSInteger kMinSubBatchSize = 20;
                            length:outputSize * channelSize * sizeof(float)
                      freeWhenDone:NO];
 
+  // weightData holds FP32 bytes on disk; pass MPSDataTypeFloat32 so
+  // weightVariableWithData performs the FP32->FP16 conversion in FP16 mode
+  // (like every other weight site). Passing parent.dataType (FP16) here would
+  // reinterpret the FP32 bytes as half, corrupting the promotion-policy logits.
   MPSGraphTensor *weightTensor = [self
       weightVariableWithData:weightData
                        shape:@[ @(outputSize), @(channelSize) ]
-                    dataType:parent.dataType
+                    dataType:MPSDataTypeFloat32
                         name:[NSString stringWithFormat:@"%@/weights", label]];
 
   keys =


### PR DESCRIPTION
## Summary

The attention-policy promotion matmul (`attentionPolicyPromoMatmulConcatWithParent` in `NetworkGraph.mm`) loaded its FP32 weight buffer with `dataType:parent.dataType`. In FP16 mode (`METALFISH_METAL_FP16=1`), `parent.dataType` is `MPSDataTypeFloat16`, so MPSGraph reinterpreted the raw FP32 bytes as half-floats and the promotion-policy logits were garbage. This is the only one of the weight-load sites that passed `parent.dataType`; every other passes `MPSDataTypeFloat32` so `weightVariableWithData` performs the FP32→FP16 conversion.

## Fix

Pass `MPSDataTypeFloat32` at the promo-weight site too.

- **Default FP32 path: no-op** — `parent.dataType` is already `Float32`, so the shipping default is byte-for-byte unchanged.
- **FP16 path: corrected** — the conversion now fires like every other weight.

## Validation

`metalfish_nn_probe` FP16 vs FP32 on a promotion position — the promotion logits now match (FP16 rounding only):

| move | FP32 | FP16 (fixed) |
| --- | ---: | ---: |
| b7a8q | 3.650 | 3.654 |
| a7a8q | 1.904 | 1.906 |
| b7a8r | 1.801 | 1.801 |

Startpos value/WDL/policy also match FP32 closely. C++ unit suite (5 modules) passes; pre-commit clean.