### PR TITLE
Fix aarch64 spin-yield to build on GCC (Linux arm64)

### DIFF
--- a/src/search/search.cpp
+++ b/src/search/search.cpp
@@ -233,7 +233,9 @@ void Search::Worker::start_searching() {
   // until the GUI sends one of those commands.
   while (!threads.stop && (main_manager()->ponder || limits.infinite)) {
 #ifdef __aarch64__
-    __builtin_arm_yield();
+    // Portable spin hint. The __builtin_arm_yield builtin is Clang-only and
+    // does not exist on GCC/aarch64; the inline-asm "yield" works on both.
+    __asm__ __volatile__("yield" ::: "memory");
 #endif
   }
 


### PR DESCRIPTION
The Linux arm64 release build failed to compile:

```
src/search/search.cpp:236: error: '__builtin_arm_yield' was not declared in this scope
```

`__builtin_arm_yield()` is a **Clang-only** builtin; GCC on aarch64 (the Linux arm64 toolchain) doesn't provide it. This never surfaced before because there was no arm64-Linux build.

Replace it with the inline-asm `yield` hint in the ponder/infinite wait loop, which both Clang and GCC accept on aarch64. Verified it still compiles cleanly under Apple Clang (aarch64); the GCC/arm64 path is validated by the cross-platform release build.

Unblocks the `linux-arm64` leg of the release workflow so v1 ships an arm64 Linux binary.